### PR TITLE
Remove additional whitespaces in the Parser

### DIFF
--- a/src/main/java/duke/duke/DialogBox.java
+++ b/src/main/java/duke/duke/DialogBox.java
@@ -19,7 +19,6 @@ public class DialogBox extends HBox {
 
     private Label text;
 
-
     public DialogBox(Label l, ImageView iv) {
 
         text = l;

--- a/src/main/java/duke/duke/Duke.java
+++ b/src/main/java/duke/duke/Duke.java
@@ -21,7 +21,10 @@ public class Duke {
     private Storage storage;
     private TaskList list;
 
-
+    /**
+     * Creates a Duke which handles responses to user inputs.
+     * @param filePath A string which denotes the path to store Duke's data.
+     */
     public Duke(String filePath) {
         this.ui = new Ui();
         this.storage = new Storage(filePath);
@@ -42,7 +45,6 @@ public class Duke {
 
     public static void main(String[] args) {
         String txtDir = System.getProperty("user.dir") + "/data/tasks.txt";
-
         Duke instance = new Duke(txtDir);
         instance.run();
     }

--- a/src/main/java/duke/duke/Parser.java
+++ b/src/main/java/duke/duke/Parser.java
@@ -71,15 +71,12 @@ public class Parser {
         case "delete":
             c = new DeleteCommand(this.singleQueryInteger(line));
             break;
-
         case "mark":
             c = new MarkCommand(this.singleQueryInteger(line), true);
             break;
-
         case "unmark":
             c = new MarkCommand(this.singleQueryInteger(line), false);
             break;
-
         case "todo":
             if (line.length == 1) {
                 throw new NoArgsException("deadline");
@@ -87,13 +84,12 @@ public class Parser {
             String description = this.queries(line, Todos.KEYWORDS).get(0);
             c = new TodoCommand(new Todos(description));
             break;
-        case "event":
+        case "event"
             if (line.length == 1) {
                 throw new NoArgsException("deadline");
             } else if (joined.split("/").length != 3) {
                 throw new InvalidException();
             }
-
             queries = this.queries(line, Events.KEYWORDS);
             Events event = new Events(queries);
             c = new EventCommand(event);
@@ -104,15 +100,12 @@ public class Parser {
             } else if (joined.split("/").length != 2) {
                 throw new InvalidException();
             }
-
             queries = this.queries(line, Deadlines.KEYWORDS);
             c = new DeadLineCommand(new Deadlines(queries));
             break;
-
         case "bye":
             c = new ByeCommand();
             break;
-
         case "find":
             if (line.length == 1) {
                 throw new NoArgsException("deadline");
@@ -120,7 +113,6 @@ public class Parser {
             String query = this.queries(line, List.<String>of()).get(0);
             c = new FindCommand(query);
             break;
-
         default:
             throw new UnrecognisableException();
         }


### PR DESCRIPTION
There are too many newlines in between lines of code. Sometimes, these newlines are not consistent, such as in the Parser class, where 1 or 2 or 0 empty lines are found between cases for the switch
  statement. To improve
readability, these newlines are removed.